### PR TITLE
Adding the documentation for the /account endpoint

### DIFF
--- a/docs/kb/api-version-3/accounts.md
+++ b/docs/kb/api-version-3/accounts.md
@@ -1,0 +1,41 @@
+
+# Querying Accounts
+
+
+## Supported Operations<a name="71862-supported-operations" id="supported-operations"></a>
+
+| **Operation** | **URL Format**                             | **Required Parameters** | **Description**  |
+| ------------- | ------------------------------------------ | ----------------------- | -----------------|
+| `read` | `/api/account/version/3/do/read` | `user_key, api_key` | Returns the data for the account of the currently logged in user. |
+
+
+## XML Response Format
+
+```
+<rsp stat="ok" version="1.0">
+    <account>
+        <id>1</id>
+        <company>Company Name</company>
+        <level>Pardot Account Level</level>
+        <website>http://www.company-website.com</website>
+        <vanity_domain>http://go.localhost.com</vanity_domain>
+        <plugin_campaign_id>1</plugin_campaign_id>
+        <tracking_code_template>[... Tracking code template ...]</tracking_code_template>
+        <address1>1234 Any Streep</address1>
+        <address2>Suite 9876</address2>
+        <city>Atlanta</city>
+        <state>Georgia</state>
+        <territory/>
+        <zip>30326</zip>
+        <country>United States</country>
+        <phone>555-555-5555</phone>
+        <fax/>
+        <created_at>2008-03-26 09:42:51</created_at>
+        <updated_at>2016-11-10 15:06:33</updated_at>
+    </account>
+</rsp>
+```
+
+| **Tag** | **Description** |
+| ------- | --------------- |
+| `<account>` | Parent tag. Contains data fields for current account.|

--- a/docs/kb/api-version-4/accounts.md
+++ b/docs/kb/api-version-4/accounts.md
@@ -1,0 +1,41 @@
+
+# Querying Accounts
+
+
+## Supported Operations<a name="71862-supported-operations" id="supported-operations"></a>
+
+| **Operation** | **URL Format**                             | **Required Parameters** | **Description**  |
+| ------------- | ------------------------------------------ | ----------------------- | -----------------|
+| `read` | `/api/account/version/3/do/read` | `user_key, api_key` | Returns the data for the account of the currently logged in user. |
+
+
+## XML Response Format
+
+```
+<rsp stat="ok" version="1.0">
+    <account>
+        <id>1</id>
+        <company>Company Name</company>
+        <level>Pardot Account Level</level>
+        <website>http://www.company-website.com</website>
+        <vanity_domain>http://go.localhost.com</vanity_domain>
+        <plugin_campaign_id>1</plugin_campaign_id>
+        <tracking_code_template>[... Tracking code template ...]</tracking_code_template>
+        <address1>1234 Any Streep</address1>
+        <address2>Suite 9876</address2>
+        <city>Atlanta</city>
+        <state>Georgia</state>
+        <territory/>
+        <zip>30326</zip>
+        <country>United States</country>
+        <phone>555-555-5555</phone>
+        <fax/>
+        <created_at>2008-03-26 09:42:51</created_at>
+        <updated_at>2016-11-10 15:06:33</updated_at>
+    </account>
+</rsp>
+```
+
+| **Tag** | **Description** |
+| ------- | --------------- |
+| `<account>` | Parent tag. Contains data fields for current account.|

--- a/docs/kb/object-field-references.md
+++ b/docs/kb/object-field-references.md
@@ -9,6 +9,123 @@ Each field returned by the API maps to a field within the Pardot user interface.
 </ul>
 
 
+## Account
+
+<table>
+<tr>
+<td><strong>Field Name&nbsp;</strong></td>
+<td><strong>Data Type&nbsp;</strong></td>
+<td><strong>Required&nbsp;</strong></td>
+<td><strong>Editable&nbsp;</strong></td>
+<td><strong>Description&nbsp;</strong></td>
+</tr>
+<tr>
+    <td>&lt;id&gt;</td>
+    <td>integer</td>
+    <td></td>
+    <td></td>
+    <td>Pardot ID for this account</td>
+</tr>
+<tr>
+    <td>&lt;level&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>The level of product for the account</td>
+</tr>
+<tr>
+    <td>&lt;website&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account website</td>
+</tr>
+<tr>
+    <td>&lt;vanity_domain&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Custom vanity domain name</td>
+</tr>
+<tr>
+    <td>&lt;plugin_campaign_id&gt;</td>
+    <td>integer</td>
+    <td></td>
+    <td></td>
+    <td>Plugin ID for account campaign</td>
+</tr>
+<tr>
+    <td>&lt;tracking_code_template&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Markup and code for use in tracking templates</td>
+</tr>
+<tr>
+    <td>&lt;address1&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact address, line 1</td>
+</tr>
+<tr>
+    <td>&lt;address2&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact address, line 2</td>
+</tr>
+<tr>
+    <td>&lt;city&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact city</td>
+</tr>
+<tr>
+    <td>&lt;state&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact state</td>
+</tr>
+<tr>
+    <td>&lt;territory&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact territory</td>
+</tr>
+<tr>
+    <td>&lt;zip&gt;</td>
+    <td>integer</td>
+    <td></td>
+    <td></td>
+    <td>Account contact zip code</td>
+</tr>
+<tr>
+    <td>&lt;country&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact country (full string)</td>
+</tr>
+<tr>
+    <td>&lt;phone&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact phone number</td>
+</tr>
+<tr>
+    <td>&lt;fax&gt;</td>
+    <td>string</td>
+    <td></td>
+    <td></td>
+    <td>Account contact fax number</td>
+</tr>
+</table>
+
 ## Campaign
 
 <table>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ pages:
 - ['kb/api-version-4/object-field-references.md', '**HIDDEN**']
 - ['kb/api-version-3/error-codes-messages.md', '**HIDDEN**']
 
+- ['kb/api-version-3/accounts.md', 'Version 3', 'Accounts']
 - ['kb/api-version-3/campaigns.md', 'Version 3', 'Campaigns']
 - ['kb/api-version-3/custom-fields.md', 'Version 3', 'Custom Fields']
 - ['kb/api-version-3/custom-redirects.md', 'Version 3', 'Custom Redirects']
@@ -41,6 +42,7 @@ pages:
 - ['kb/api-version-3/visits.md', 'Version 3', 'Visits']
 
 
+- ['kb/api-version-4/accounts.md', 'Version 4', 'Accounts']
 - ['kb/api-version-4/campaigns.md', 'Version 4', 'Campaigns']
 - ['kb/api-version-4/custom-fields.md', 'Version 4', 'Custom Fields']
 - ['kb/api-version-4/custom-redirects.md', 'Version 4', 'Custom Redirects']


### PR DESCRIPTION
This PR adds in the (brief) documentation for the `/account` endpoint to both the v3 and v4 documentation.