### PR TITLE
W-5497140: Update API auth details for security updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * `open http://127.0.0.1:8000/`
 
 Make sure your MkDocs is up-to-date. Current Version: 0.15.2. To upgrade:
-* `pip install -U mkdocs`
+* `pip install -U mkdocs` - or - `pip install -I mkdocs==0.15.2`
 
 See the [mkdocs](http://www.mkdocs.org/#getting-started) website for more information.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,39 +21,48 @@ Developers must authenticate with the API before issuing requests.  Refer to the
 
 Some considerations must be taken while performing requests. When performing `update` requests, only the fields specified in the request are updated, and all others are left unchanged. If a required field is cleared during an `update`, the request will be declined.
 
-The Pardot API handles a variety of requests for many of the
-objects available through the Pardot user interface. Most requests
-to the API use the following standardized format. All requests must
-use either HTTP GET or POST. Although GET requests are secure due
-to the use of SSL, we recommend using POST, with sensitive or
-lengthy parameter values being part of the POST message body.
-Developers are responsible for issuing requests with the following
-components:
+### Request Format
+
+All requests to the API: 
+
+* Must use either HTTP `GET` or `POST`
+* Must pass credentials in an HTTP `Authorization` header - or - in the body of a `POST` request
+
+> NOTE: Support for passing credentials via querystring is deprecated and will be forbidden in a future version of the API. Please update your API client as soon as possible.
+
+#### Sample GET Request
 
 ```
-POST: https://pi.pardot.com/api/<object>/version/3/do/<operator>/<identifier_field>/<identifier>
-message body: api_key=<your_api_key>&user_key=<your_user_key>&<parameters_for_request>
-
-GET: https://pi.pardot.com/api/<object>/version/3/do/<operator>/<identifier_field>/<identifier>?api_key=<your_api_key>&user_key=<your_user_key>&<parameters_for_request>
+GET https://pi.pardot.com/api/<object>/version/3/do/<op>/<id_field>/<id>?<params> HTTP/1.1
+Authorization: Pardot api_key=<your_api_key>, user_key=<your_user_key>
 ```
 
-| **Parameter** | **Required**   | **Description**                                        |
-| ------------- | :------------: | ----------------------------------------------------- |
-| `object`       | X              | The object type to be returned by the API request                |
-| `operator`    | X              | The operation to be performed on the specified object type                    |
-| `identifier_field`    | X              | The field to be used as the identifier for the specified object  |
-| `identifier`       | X              | The identifier for the specified object(s)              |
-| `your_api_key`    | X              | The API key that was obtained during [Authentication](#authentication)                   |
-| `your_user_key`    | X              | The user key that was used during [Authentication](#authentication)  |
-| `format`    |               | The API data format. Either xml or json (xml is default)                   |
-| `parameters_for_request`    |               | Parameters specific to your request; See individual methods for details |
+#### Sample POST Request
 
-The ordering of parameters is arbitrary. Parameters are passed using conventional HTML parameter syntax, with `'?'` indicating the start of the parameter string (for GET requests only) and `'&'` as the separator between parameters. With the exception of `<format>` and `<parameters_for_request>`, all components are required. Data returned from the API is formatted using JSON or XML 1.0 with UTF-8 character encoding. Keep in mind that some characters in the response may be encoded as HTML entities, requiring client-side decoding. Also, keep in mind that all parameters specified in an API request MUST be URL-encoded before they are submitted.
+```
+POST https://pi.pardot.com/api/<object>/version/3/do/<op>/<id_field>/<id> HTTP/1.1
+
+api_key=<your_api_key>&user_key=<your_user_key>&<params>
+```
+
+#### Request Parameters
+
+| **Parameter**            | **Required**   | **Description**                                                         |
+| ------------------------ | -------------- | ----------------------------------------------------------------------- |
+| `object`                 | X              | The object type to be returned by the API request                       |
+| `op`                     | X              | The operation to be performed on the specified object type              |
+| `id_field`               | X              | The field to be used as the identifier for the specified object         |
+| `id`                     | X              | The identifier for the specified object(s)                              |
+| `your_api_key`           | X              | The API key that was obtained during [Authentication](#authentication)  |
+| `your_user_key`          | X              | The user key that was used during [Authentication](#authentication)     |
+| `format`                 |                | The API data format. Either xml or json (xml is default)                |
+| `params`                 |                | Parameters specific to your request; See individual methods for details |
+
+The ordering of parameters is arbitrary. Parameters are passed using conventional HTML parameter syntax, with `'?'` indicating the start of the parameter string (for GET requests only) and `'&'` as the separator between parameters. With the exception of `<format>` and `<params>`, all components are required. Data returned from the API is formatted using JSON or XML 1.0 with UTF-8 character encoding. Keep in mind that some characters in the response may be encoded as HTML entities, requiring client-side decoding. Also, keep in mind that all parameters specified in an API request MUST be URL-encoded before they are submitted.
 
 In general, the API will return XML or JSON containing a current version of the target object's data. However, unsuccessful requests will return a short response containing an error code and message. See [Error Codes &amp; Messages](kb/api-version-3/error-codes-messages) for error descriptions and suggested remedies.
 
-<a name="14767-changing-xml-response-format" id=
-"changing-xml-response-format"></a>
+<a name="14767-changing-xml-response-format" id="changing-xml-response-format"></a>
 
 ## Version 3 and Version 4 differences
 
@@ -84,29 +93,37 @@ If the output request parameter is not defined, the output format defaults to `f
 
 ## Authentication
 
-A few prerequisites must be met to successfully authenticate a
-connection to the API.
+### Request Format
 
-1.  All requests to the Pardot API must be made via SSL encrypted
-connection.
-2.  Authentication requests must use HTTP POST.
-3.  Obtain the `email`, `password`, and `user_key` (available in Pardot under **{your email address} > Settings** in the API User Key row) for the Pardot user account that will be submitting API requests. If you need assistance in acquiring your user key, contact your Pardot support representative.
+Authentication requests sent to the Pardot API:
 
-With these requirements met, an API key must be acquired. Both User and API keys are unique to individual users. API keys are valid for 60 minutes. In contrast, user keys are valid indefinitely. To authenticate, issue the following request (having replaced the values denoted by `<carets>` with values for your account):
+1.  Must be made via SSL encrypted connection
+2.  Must use HTTP `POST`
+3.  Must contain the `email`, `password`, and `user_key` for the Pardot user account that will be submitting API requests
+
+Login requests that meet these criteria will be granted an API key. 
+
+API user keys are available in Pardot under **{your email address} > Settings** in the API User Key row. If you need assistance in acquiring your user key, contact your Pardot support representative.
+
+> Both User and API keys are unique to individual users. API keys are valid for 60 minutes. In contrast, user keys are valid indefinitely. 
+
+#### Sample POST Request
 
 ```
-POST: https://pi.pardot.com/api/login/version/3
-message body: email=<email>&password=<password>&user_key=<user_key>
+POST https://pi.pardot.com/api/login/version/3 HTTP/1.1
+
+email=<email>&password=<password>&user_key=<user_key>
 ```
 
-| **Parameter** | **Required**   | **Description**                                        |
-| ------------- | :------------: | ----------------------------------------------------- |
-| `email`       | X              | The email address of your user account                 |
-| `password`    | X              | The password of your user account                      |
+#### Request Parameters
+
+| **Parameter** | **Required**   | **Description**                                              |
+| ------------- | -------------- | ------------------------------------------------------------ |
+| `email`       | X              | The email address of your user account                       |
+| `password`    | X              | The password of your user account                            |
 | `user_key`    | X              | The 32-character hexadecimal user key for your user account  |
 
-If authentication was successful, a 32-character hexadecimal API
-key will be returned in the following format:
+If authentication was successful, a 32-character hexadecimal API key will be returned in the following format:
 
 ```
 <rsp stat="ok" version="1.0">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # Official Pardot API Documentation
 
+> **IMPORTANT: Support for passing credentials via querystring is deprecated and will be forbidden in a future version of the API. Please update your API client as soon as possible.**
+>
+> Refer to the [Using the API > Request Format](#using-the-api) section below for further details.
+
 Welcome! All up-to-date documentation of Pardot's official API is housed here. A few things of note:
 
 * If you have a question about the API, feel free to [open a ticket](https://help.salesforce.com/articleView?id=000181929&type=1) with our Support team.
@@ -27,8 +31,6 @@ All requests to the API:
 
 * Must use either HTTP `GET` or `POST`
 * Must pass credentials in an HTTP `Authorization` header - or - in the body of a `POST` request
-
-> NOTE: Support for passing credentials via querystring is deprecated and will be forbidden in a future version of the API. Please update your API client as soon as possible.
 
 #### Sample GET Request
 

--- a/docs/kb/release-notes.md
+++ b/docs/kb/release-notes.md
@@ -2,6 +2,9 @@
 
 This page contains the release notes for the Pardot API and related documentation.
 
+## October 2018
+* updated "Using the API" and "Authentication" sections to inform that passing credentials via querystring params is now deprecated
+
 ## February 2018
 * fixed a few typos in the docs
 * added information regarding campaign alignment


### PR DESCRIPTION
# Overview
These changes update our documentation to reflect security-motivated changes in authentication for the Pardot API. As we move to deprecate support for honoring credentials passed in the URL as querystring parameters, we want to communicate our preferred authentication patterns.

The screenshots below reflect the relevant changes to our API documentation.

## Title
![image](https://user-images.githubusercontent.com/13754012/47106873-b9e8fb80-d215-11e8-804f-d45cd7a80c8d.png)
## General Authentication
![image](https://user-images.githubusercontent.com/13754012/47106587-f9fbae80-d214-11e8-9c06-4e73c29673d4.png)
## Login
![image](https://user-images.githubusercontent.com/13754012/47086870-9b204000-d1e8-11e8-96f3-c8df32a41752.png)
