### PR TITLE
 W-5682455 Add archived parameter documentation

### DIFF
--- a/docs/kb/api-version-3/email-templates.md
+++ b/docs/kb/api-version-3/email-templates.md
@@ -12,7 +12,7 @@
 
 | Parameter              | Required         | Type                                                                | Description |
 |------------------------|------------------|------------------------------------------------------------------------|-------------|
-| archived |  | boolean | When set to true, archived and unarchived email templates are returned from the endpoint. _Defaults to_ `false`. |
+| archived |  | boolean | When set to true, archived and unarchived email templates are returned from the endpoint. When false, unarchived templates will be returned and archived templates will not be found (as if no email template exists for the specified ID). _Defaults to_ `false`. |
 
 
 ## XML Response Format

--- a/docs/kb/api-version-3/email-templates.md
+++ b/docs/kb/api-version-3/email-templates.md
@@ -8,6 +8,12 @@
 | ------------- | ------------------------------------------ | ----------------------- | -----------------|
 | `read` | `/api/emailTemplate/version/3/do/read/id/<email template id>` | `user_key, api_key, emailTemplateId` | Returns the data for the email template specified by `<id>`. `<id>` is the Pardot ID of the target email template. |
 
+## [](#supported-parameters-)Supported Parameters
+
+| Parameter              | Required         | Type                                                                | Description |
+|------------------------|------------------|------------------------------------------------------------------------|-------------|
+| archived |  | boolean | When set to true, archived and unarchived email templates are returned from the endpoint. _Defaults to_ `false`. |
+
 
 ## XML Response Format
 
@@ -60,6 +66,12 @@
 | **Operation** | **URL Format**                             | **Required Parameters** | **Description**  |
 | ------------- | ------------------------------------------ | ----------------------- | -----------------|
 | `listOneToOne` | `/api/emailTemplate/version/3/do/listOneToOne` | `user_key, api_key` | Returns a list of email templates which are enabled for use in one to one emails. |
+
+## [](#71862-supported-parameters-)Supported Parameters
+
+| Parameter              | Required         | Type                                                                | Description |
+|------------------------|------------------|------------------------------------------------------------------------|-------------|
+| archived |  | boolean | When set to true, archived and unarchived email templates are returned from the endpoint. _Defaults to_ `false`. |
 
 ## XML Response Format
 

--- a/docs/kb/api-version-4/email-templates.md
+++ b/docs/kb/api-version-4/email-templates.md
@@ -8,6 +8,11 @@
 | ------------- | ------------------------------------------ | ----------------------- | -----------------|
 | `read` | `/api/emailTemplate/version/4/do/read/id/<email template id>` | `user_key, api_key, emailTemplateId` | Returns the data for the email template specified by `<id>`. `<id>` is the Pardot ID of the target email template. |
 
+## [](#supported-parameters-)Supported Parameters
+
+| Parameter              | Required         | Type                                                                | Description |
+|------------------------|------------------|------------------------------------------------------------------------|-------------|
+| archived |  | boolean | When set to true, archived and unarchived email templates are returned from the endpoint. When false, unarchived templates will be returned and archived templates will not be found (as if no email template exists for the specified ID). _Defaults to_ `false`. |
 
 ## XML Response Format
 
@@ -60,6 +65,12 @@
 | **Operation** | **URL Format**                             | **Required Parameters** | **Description**  |
 | ------------- | ------------------------------------------ | ----------------------- | -----------------|
 | `listOneToOne` | `/api/emailTemplate/version/4/do/listOneToOne` | `user_key, api_key` | Returns a list of email templates which are enabled for use in one to one emails. |
+
+## [](#71862-supported-parameters-)Supported Parameters
+
+| Parameter              | Required         | Type                                                                | Description |
+|------------------------|------------------|------------------------------------------------------------------------|-------------|
+| archived |  | boolean | When set to true, archived and unarchived email templates are returned from the endpoint. _Defaults to_ `false`. |
 
 ## XML Response Format
 


### PR DESCRIPTION
EmailTemplate endpoints /read and /listOneToOne now support an `archived` query string parameter, which allows for EmailTemplates that have been archived to be returned. This pull-request is to update the documentation to reflect the change.