### PR TITLE
Add horizontal rules to navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ pages:
 - ['kb/api-version-3/visitors.md', 'Version 3', 'Visitors']
 - ['kb/api-version-3/visitor-activities.md', 'Version 3', 'Visitor Activities']
 - ['kb/api-version-3/visits.md', 'Version 3', 'Visits']
-- ['kb/api-version-3/import.md', 'Version 3', 'Import API (for Prospects)']
+- ['kb/api-version-3/import.md', 'Version 3', '--Import API (for Prospects)']
 
 - ['kb/api-version-4/accounts.md', 'Version 4', 'Accounts']
 - ['kb/api-version-4/campaigns.md', 'Version 4', 'Campaigns']
@@ -65,6 +65,6 @@ pages:
 - ['kb/api-version-4/visitors.md', 'Version 4', 'Visitors']
 - ['kb/api-version-4/visitor-activities.md', 'Version 4', 'Visitor Activities']
 - ['kb/api-version-4/visits.md', 'Version 4', 'Visits']
-- ['kb/api-version-4/import.md', 'Version 4', 'Import API (for Prospects)']
+- ['kb/api-version-4/import.md', 'Version 4', '--Import API (for Prospects)']
 
 theme_dir: 'pardot_theme'

--- a/pardot_theme/base.html
+++ b/pardot_theme/base.html
@@ -10,7 +10,7 @@
         {% if favicon %}<link rel="shortcut icon" href="{{ favicon }}">
         {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
 
-        <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+        <title>{% if page_title %}{% if page_title.startswith('--') %}{{ page_title[2:] }}{% else %}{{ page_title }}{% endif %} - {% endif %}{{ site_name }}</title>
 
         <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
         <link href="{{ base_url }}/css/font-awesome-4.0.3.css" rel="stylesheet">

--- a/pardot_theme/css/base.css
+++ b/pardot_theme/css/base.css
@@ -252,6 +252,9 @@ div.source-links {
 	color: #7e7f80;
 	background-color: #ecf0f3;
 }
+.dropdown-menu > .separator-above {
+	border-top: 1px solid #c8cbce;
+}
 
 .navbar-default .navbar-nav > li > a {
 	color: #999;

--- a/pardot_theme/nav.html
+++ b/pardot_theme/nav.html
@@ -26,8 +26,14 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                         <ul class="dropdown-menu">
                         {% for nav_item in nav_item.children %}
-                            <li {% if nav_item.active %}class="active"{% endif %}>
-                                <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+                            <li class="{% if nav_item.active %}active{% endif %} {% if nav_item.title.startswith('--') %}separator-above{% endif %}">
+                                <a href="{{ nav_item.url }}">
+                                    {% if nav_item.title.startswith('--') %}
+                                    {{ nav_item.title[2:] }}
+                                    {% else %}
+                                    {{ nav_item.title }}
+                                    {% endif %}
+                                </a>
                             </li>
                         {% endfor %}
                         </ul>
@@ -49,14 +55,24 @@
                 {% if previous_page and page_title != 'Pardot API Documentation' %}
                 <li>
                     <a rel="next" {% if previous_page %}href="{{ previous_page.url }}"{% endif %}>
-                    <i class="fa fa-arrow-left"></i> {{ previous_page.title }}
+                    <i class="fa fa-arrow-left"></i>
+                    {% if previous_page.title .startswith('--') %}
+                    {{ previous_page.title[2:] }}
+                    {% else %}
+                    {{ previous_page.title }}
+                    {% endif %}
                     </a>
                 </li>
                 {% endif %}
                 {% if next_page %}
                 <li>
                     <a rel="prev" {% if next_page %}href="{{ next_page.url }}"{% endif %}>
-                    {{ next_page.title }} <i class="fa fa-arrow-right"></i>
+                    {% if next_page.title .startswith('--') %}
+                    {{ next_page.title[2:] }}
+                    {% else %}
+                    {{ next_page.title }}
+                    {% endif %}
+                    <i class="fa fa-arrow-right"></i>
                     </a>
                 </li>
                 {% endif %}


### PR DESCRIPTION
The mkdocs framework doesn't support passing arbitrary data in with pages so this PR adds special formatting when the title of the page starts with "--", similar to how `**HIDDEN**` is handled. The places in the code where the title property is shown have been modified to remove the extra "--" characters.

![Screen Shot 2019-08-27 at 9 19 49 AM](https://user-images.githubusercontent.com/1672741/63791204-d6cb7200-c8af-11e9-8ec3-37068cfa8884.png)
